### PR TITLE
Small documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 21API
 
-Python API able to get chains from web-app database and automaticly
+Python API able to get chains from web-app database and automatically
 writes/secure them on the bitcoin blockchain via 21 micropayment services.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # 21API
-Python API able to get chains from web-app database and automaticly writes/secure them on the bitcoin blockchain via 21 micropayment services.
+
+Python API able to get chains from web-app database and automaticly
+writes/secure them on the bitcoin blockchain via 21 micropayment services.

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -4,7 +4,8 @@
 Web browser <--> Front-end <--> **api.py <--> connector.py**
 
 ## api.py
-RESTful service for vote saving. This module only receives and transmit information to the connector.py script and to the front-end instances.
+RESTful service for vote saving. This module only receives and transmit
+information to the connector.py script and to the front-end instances.
 
 Resource | HTTP Method | URL and arguments | Returns
 ----|-----|----- |-----|
@@ -14,7 +15,9 @@ Vote status | GET | <host:port>/vote-count | Total number of votes on each optio
 
 
 ## connector.py
-21.co server for operations over micropayments (One satoshi per operation). This connector provides information for the api.py module and manages the operations for Blockchain events
+21.co server for operations over micropayments (One satoshi per operation). This
+connector provides information for the api.py module and manages the operations
+for Blockchain events
 
 Resource | HTTP Method | URL and arguments | Returns
 ----|-----|-----|-----|

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -4,7 +4,7 @@
 Web browser <--> Front-end <--> **api.py <--> connector.py**
 
 ## api.py
-RESTful service for vote saving. This module only receives and transmit
+RESTful service for vote saving. This module only receives and transmits
 information to the connector.py script and to the front-end instances.
 
 Resource | HTTP Method | URL and arguments | Returns

--- a/src/api.py
+++ b/src/api.py
@@ -18,7 +18,7 @@ server_url = 'http://localhost:8000/'
 # Start flask service
 app = Flask(__name__)
 
-#definition of micropayment_sendvote function
+# definition of micropayment_sendvote function
 def micropayment_sendvote(proposal):
 	'''
 	Function: micropayment_sendvote()
@@ -52,7 +52,7 @@ def sendvote():
 	}
 	return jsonify(vote)
 
-#/vote-count
+# /vote-count
 @app.route('/vote-count', methods=['GET'])
 def grabvotes():
 	sel_url = server_url + 'count'


### PR DESCRIPTION
This PR:
- Fixes line lengths that overrun 80 characters in `readme.md` and `docs/api_endpoints.md`
- Fixes a misspelled work and instance of a singular tense that should have been pluralized
